### PR TITLE
Add GetStopPredictions, as well as some minor clean-up

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -46,9 +46,9 @@ func main() {
     fmt.Println(predictions)
 
     // Get predictions for all routes at stop with id 14961.
-    stopPreds, perr := nb.GetStopPredictions("sf-muni", "14961")
+    stopPreds, sperr := nb.GetStopPredictions("sf-muni", "14961")
     if perr != nil {
-        fmt.Println(perr)
+        fmt.Println(sperr)
     }
     fmt.Println(stopPreds)
 }

--- a/Readme.md
+++ b/Readme.md
@@ -47,7 +47,7 @@ func main() {
 
     // Get predictions for all routes at stop with id 14961.
     stopPreds, sperr := nb.GetStopPredictions("sf-muni", "14961")
-    if perr != nil {
+    if sperr != nil {
         fmt.Println(sperr)
     }
     fmt.Println(stopPreds)

--- a/Readme.md
+++ b/Readme.md
@@ -38,12 +38,19 @@ func main() {
     }
     fmt.Println(rconfig)
 
+    // Get predictions for the N train at stop with tag 5205.
     predictions, perr := nb.GetPredictions("sf-muni", "N", "5205")
     if perr != nil {
         fmt.Println(perr)
     }
     fmt.Println(predictions)
 
+    // Get predictions for all routes at stop with id 14961.
+    stopPreds, perr := nb.GetStopPredictions("sf-muni", "14961")
+    if perr != nil {
+        fmt.Println(perr)
+    }
+    fmt.Println(stopPreds)
 }
 ```
 

--- a/nextbus.go
+++ b/nextbus.go
@@ -40,19 +40,18 @@ type Agency struct {
 func (c *Client) GetAgencyList() ([]Agency, error) {
 	resp, httpErr := c.httpClient.Get("http://webservices.nextbus.com/service/publicXMLFeed?command=agencyList")
 	if httpErr != nil {
-		return nil, httpErr
+		return nil, fmt.Errorf("could not fetch agencies from nextbus: %v", httpErr)
 	}
 	defer resp.Body.Close()
 
 	body, readErr := ioutil.ReadAll(resp.Body)
 	if readErr != nil {
-		return nil, readErr
+		return nil, fmt.Errorf("could not parse agencies response body: %v", readErr)
 	}
 
 	var a AgencyResponse
-	xmlErr := xml.Unmarshal(body, &a)
-	if xmlErr != nil {
-		return nil, xmlErr
+	if xmlErr := xml.Unmarshal(body, &a); xmlErr != nil {
+		return nil, fmt.Errorf("could not parse agencies XML: %v", xmlErr)
 	}
 	return a.AgencyList, nil
 }
@@ -74,19 +73,19 @@ type Route struct {
 func (c *Client) GetRouteList(agencyTag string) ([]Route, error) {
 	resp, httpErr := c.httpClient.Get("http://webservices.nextbus.com/service/publicXMLFeed?command=routeList&a=" + agencyTag)
 	if httpErr != nil {
-		return nil, httpErr
+		return nil, fmt.Errorf("could not fetch routes from nextbus: %v", httpErr)
 	}
 	defer resp.Body.Close()
 
 	body, readErr := ioutil.ReadAll(resp.Body)
 	if readErr != nil {
-		return nil, readErr
+		return nil, fmt.Errorf("could not parse routes response body: %v", readErr)
 	}
 
 	var a RouteResponse
 	xmlErr := xml.Unmarshal(body, &a)
 	if xmlErr != nil {
-		return nil, xmlErr
+		return nil, fmt.Errorf("could not parse routes XML: %v", xmlErr)
 	}
 	return a.RouteList, nil
 }
@@ -188,19 +187,18 @@ func (c *Client) GetRouteConfig(agencyTag string, configParams ...RouteConfigPar
 	}
 	resp, httpErr := c.httpClient.Get("http://webservices.nextbus.com/service/publicXMLFeed?" + strings.Join(params, "&"))
 	if httpErr != nil {
-		return nil, httpErr
+		return nil, fmt.Errorf("could not fetch route config from nextbus: %v", httpErr)
 	}
 	defer resp.Body.Close()
 
 	body, readErr := ioutil.ReadAll(resp.Body)
 	if readErr != nil {
-		return nil, readErr
+		return nil, fmt.Errorf("could not parse route config response body: %v", readErr)
 	}
 
 	var a RouteConfigResponse
-	xmlErr := xml.Unmarshal(body, &a)
-	if xmlErr != nil {
-		return nil, xmlErr
+	if xmlErr := xml.Unmarshal(body, &a); xmlErr != nil {
+		return nil, fmt.Errorf("could not parse route config XML: %v", xmlErr)
 	}
 	return a.RouteList, nil
 }
@@ -261,19 +259,18 @@ type Message struct {
 func (c *Client) GetStopPredictions(agencyTag string, stopID string) ([]PredictionData, error) {
 	resp, httpErr := c.httpClient.Get("http://webservices.nextbus.com/service/publicXMLFeed?command=predictions&a=" + agencyTag + "&stopId=" + stopID)
 	if httpErr != nil {
-		return nil, httpErr
+		return nil, fmt.Errorf("could not fetch stop predictions from nextbus: %v", httpErr)
 	}
 	defer resp.Body.Close()
 
 	body, readErr := ioutil.ReadAll(resp.Body)
 	if readErr != nil {
-		return nil, readErr
+		return nil, fmt.Errorf("could not parse stop predictions response body: %v", readErr)
 	}
 
 	var a PredictionResponse
-	xmlErr := xml.Unmarshal(body, &a)
-	if xmlErr != nil {
-		return nil, xmlErr
+	if xmlErr := xml.Unmarshal(body, &a); xmlErr != nil {
+		return nil, fmt.Errorf("could not parse stop predictions XML: %v", xmlErr)
 	}
 	return a.PredictionDataList, nil
 }
@@ -283,19 +280,18 @@ func (c *Client) GetStopPredictions(agencyTag string, stopID string) ([]Predicti
 func (c *Client) GetPredictions(agencyTag string, routeTag string, stopTag string) ([]PredictionData, error) {
 	resp, httpErr := c.httpClient.Get("http://webservices.nextbus.com/service/publicXMLFeed?command=predictions&a=" + agencyTag + "&r=" + routeTag + "&s=" + stopTag)
 	if httpErr != nil {
-		return nil, httpErr
+		return nil, fmt.Errorf("could not fetch predictions from nextbus: %v", httpErr)
 	}
 	defer resp.Body.Close()
 
 	body, readErr := ioutil.ReadAll(resp.Body)
 	if readErr != nil {
-		return nil, readErr
+		return nil, fmt.Errorf("could not parse predictions response body: %v", readErr)
 	}
 
 	var a PredictionResponse
-	xmlErr := xml.Unmarshal(body, &a)
-	if xmlErr != nil {
-		return nil, xmlErr
+	if xmlErr := xml.Unmarshal(body, &a); xmlErr != nil {
+		return nil, fmt.Errorf("could not parse predictions XML: %v", xmlErr)
 	}
 	return a.PredictionDataList, nil
 }
@@ -330,19 +326,18 @@ func (c *Client) GetPredictionsForMultiStops(agencyTag string, params ...PredReq
 
 	resp, httpErr := c.httpClient.Get("http://webservices.nextbus.com/service/publicXMLFeed?" + strings.Join(queryParams, "&"))
 	if httpErr != nil {
-		return nil, httpErr
+		return nil, fmt.Errorf("could not fetch predictions for multiple stops from nextbus: %v", httpErr)
 	}
 	defer resp.Body.Close()
 
 	body, readErr := ioutil.ReadAll(resp.Body)
 	if readErr != nil {
-		return nil, readErr
+		return nil, fmt.Errorf("could not parse predictions for multiple stops response body: %v", readErr)
 	}
 
 	var a PredictionResponse
-	xmlErr := xml.Unmarshal(body, &a)
-	if xmlErr != nil {
-		return nil, xmlErr
+	if xmlErr := xml.Unmarshal(body, &a); xmlErr != nil {
+		return nil, fmt.Errorf("could not parse predictions for multiple stops XML: %v", xmlErr)
 	}
 	return a.PredictionDataList, nil
 }
@@ -411,20 +406,20 @@ func (c *Client) GetVehicleLocations(agencyTag string, configParams ...VehicleLo
 	if !timeWasSet {
 		params = append(params, VehicleLocationTime("0")())
 	}
-	resp, err := c.httpClient.Get("http://webservices.nextbus.com/service/publicXMLFeed?" + strings.Join(params, "&"))
-	if err != nil {
-		return nil, err
+	resp, httpErr := c.httpClient.Get("http://webservices.nextbus.com/service/publicXMLFeed?" + strings.Join(params, "&"))
+	if httpErr != nil {
+		return nil, fmt.Errorf("could not fetch vehicle locations from nextbus: %v", httpErr)
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
+	body, readErr := ioutil.ReadAll(resp.Body)
+	if readErr == nil {
+		return nil, fmt.Errorf("could not parse vehicle locations response body: %v", readErr)
 	}
 
 	var result LocationResponse
-	if err = xml.Unmarshal(body, &result); err != nil {
-		return nil, err
+	if xmlErr := xml.Unmarshal(body, &result); xmlErr != nil {
+		return nil, fmt.Errorf("could not parse vehicle locations XML: %v", xmlErr)
 	}
 	return &result, nil
 }

--- a/nextbus.go
+++ b/nextbus.go
@@ -255,6 +255,29 @@ type Message struct {
 	Priority string   `xml:"priority,attr"`
 }
 
+// GetStopPredictions fetches a set of predictions for a transit agency at the
+// provided stop. Note that this requires the 'stopID' which is the unique
+// identifier for a stop indepenedent of a route.
+func (c *Client) GetStopPredictions(agencyTag string, stopID string) ([]PredictionData, error) {
+	resp, httpErr := c.httpClient.Get("http://webservices.nextbus.com/service/publicXMLFeed?command=predictions&a=" + agencyTag + "&stopId=" + stopID)
+	if httpErr != nil {
+		return nil, httpErr
+	}
+	defer resp.Body.Close()
+
+	body, readErr := ioutil.ReadAll(resp.Body)
+	if readErr != nil {
+		return nil, readErr
+	}
+
+	var a PredictionResponse
+	xmlErr := xml.Unmarshal(body, &a)
+	if xmlErr != nil {
+		return nil, xmlErr
+	}
+	return a.PredictionDataList, nil
+}
+
 // GetPredictions fetches a set of predictions for a transit agency at the
 // provided route and stop.
 func (c *Client) GetPredictions(agencyTag string, routeTag string, stopTag string) ([]PredictionData, error) {

--- a/nextbus_test.go
+++ b/nextbus_test.go
@@ -65,6 +65,22 @@ var fakes = map[string]string{
 <lastTime time="1234567890123"/>
 </body>
 `,
+	makeURL("predictions", "a", "alpha", "stopId", "11123"): `
+<body copyright="All data copyright some transit company.">
+<predictions agencyTitle="some transit company" routeTitle="The First" routeTag="1" stopTitle="Some Station Outbound" stopTag="1123">
+<direction title="Outbound">
+<prediction epochTime="1490564618948" seconds="623" minutes="10" isDeparture="false" dirTag="7____O_F00" vehicle="6581" block="0712" tripTag="7447642"/>
+<prediction epochTime="1490565376790" seconds="1381" minutes="23" isDeparture="false" affectedByLayover="true" dirTag="7____O_F00" vehicle="6720" block="0705" tripTag="7447643"/>
+</direction>
+</predictions>
+<predictions agencyTitle="some transit company" routeTitle="The Second" routeTag="2" stopTitle="Some Station Outbound" stopTag="1123">
+<direction title="Outbound">
+<prediction epochTime="1490564681782" seconds="686" minutes="11" isDeparture="false" dirTag="6____O_F00" vehicle="8618" block="0609" tripTag="7447028"/>
+<prediction epochTime="1490565307084" seconds="1311" minutes="21" isDeparture="false" dirTag="6____O_F00" vehicle="8807" block="0602" tripTag="7447029"/>
+</direction>
+</predictions>
+</body>
+`,
 	makeURL("predictionsForMultiStops", "a", "alpha", "stops", "1|1123", "stops", "1|1124"): `
 <body copyright="All data copyright some transit company.">
 <predictions agencyTitle="some transit company" routeTitle="The First" routeTag="1" stopTitle="Some Station Outbound" stopTag="1123">
@@ -234,6 +250,102 @@ func TestGetVehicleLocations(t *testing.T) {
 		LocationLastTime{xmlName("lastTime"), "1234567890123"},
 	}
 	equals(t, &expected, found)
+}
+
+func TestGetStopPredictions(t *testing.T) {
+	nb := NewClient(testingClient(t))
+	found, err := nb.GetStopPredictions("alpha", "11123")
+	ok(t, err)
+
+	expected := []PredictionData{
+		PredictionData{
+			xmlName("predictions"),
+			[]PredictionDirection{
+				PredictionDirection{
+					xmlName("direction"),
+					[]Prediction{
+						Prediction{
+							xmlName("prediction"),
+							"1490564618948",
+							"623",
+							"10",
+							"false",
+							"",
+							"7____O_F00",
+							"6581",
+							"",
+							"0712",
+							"7447642",
+						},
+						Prediction{
+							xmlName("prediction"),
+							"1490565376790",
+							"1381",
+							"23",
+							"false",
+							"true",
+							"7____O_F00",
+							"6720",
+							"",
+							"0705",
+							"7447643",
+						},
+					},
+					"Outbound",
+				},
+			},
+			nil,
+			"some transit company",
+			"The First",
+			"1",
+			"Some Station Outbound",
+			"1123",
+		},
+		PredictionData{
+			xmlName("predictions"),
+			[]PredictionDirection{
+				PredictionDirection{
+					xmlName("direction"),
+					[]Prediction{
+						Prediction{
+							xmlName("prediction"),
+							"1490564681782",
+							"686",
+							"11",
+							"false",
+							"",
+							"6____O_F00",
+							"8618",
+							"",
+							"0609",
+							"7447028",
+						},
+						Prediction{
+							xmlName("prediction"),
+							"1490565307084",
+							"1311",
+							"21",
+							"false",
+							"",
+							"6____O_F00",
+							"8807",
+							"",
+							"0602",
+							"7447029",
+						},
+					},
+					"Outbound",
+				},
+			},
+			nil,
+			"some transit company",
+			"The Second",
+			"2",
+			"Some Station Outbound",
+			"1123",
+		},
+	}
+	equals(t, expected, found)
 }
 
 func TestGetPredictionsForMultiStops(t *testing.T) {


### PR DESCRIPTION
dinedal, I've been using your library to write my CLI [tool](https://github.com/wallaceicy06/nextbus-cli) for nextbus predictions. I wanted a method to list all predictions for a stop independent of route, so went ahead and wrote it into your library. I also made some minor changes to make `golint` happy and make the error messages more descriptive. Thanks again for the original work; saved me a lot of boilerplate!